### PR TITLE
fix bug where a blank line could delete all config

### DIFF
--- a/napalm_opengear/opengear.py
+++ b/napalm_opengear/opengear.py
@@ -132,15 +132,16 @@ class OpenGearDriver(NetworkDriver):
 
         candidate = ["=".join(line.split(" ", 1)) for line in candidate if line]
         for command in candidate:
-            if '=' not in command:  # assignment via `=` means set a vaule
-                command = 'sudo config -d "{0}"'.format(command.strip())
-                # print(command)
-            else:  # no assignment, means delete the value
-                command = 'sudo config -s "{0}"'.format(command.strip())
-                # print(command)
-            output = self._send_command(command)
-            if "error" in output or "not found" in output:
-                raise MergeConfigException("Command '{0}' cannot be applied.".format(command))
+            if command.strip(): # skip blank lines from creating a `config -d ""`
+                if '=' not in command:  # assignment via `=` means set a vaule
+                    command = 'sudo config -d "{0}"'.format(command.strip())
+                    # print(command)
+                else:  # no assignment, means delete the value
+                    command = 'sudo config -s "{0}"'.format(command.strip())
+                    # print(command)
+                output = self._send_command(command)
+                if "error" in output or "not found" in output:
+                    raise MergeConfigException("Command '{0}' cannot be applied.".format(command))
         self.loaded = True
 
     def get_config(self, retrieve='all'):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def parse_reqs(file_path):
 
 setup(
 	name="napalm-opengear",
-	version="0.3.0",
+	version="0.3.1",
 	packages=find_packages(),
 	author="Charlie Allom",
 	author_email="charlie@evilforbeginners.com",


### PR DESCRIPTION
on some opengears (only 2 out of my entire fleet) I could trigger a bug where `load_merge_candidate()` with an empty line in a config file would make it emit `sudo config -d ""`

Which of course is not great.