### PR TITLE
Fix candidate passed as text, and optimize load

### DIFF
--- a/napalm_opengear/opengear.py
+++ b/napalm_opengear/opengear.py
@@ -125,23 +125,23 @@ class OpenGearDriver(NetworkDriver):
             with open(filename, 'r') as f:
                 candidate = f.readlines()
         else:
-            candidate = config
+            candidate = config.splitlines()
 
         if not isinstance(candidate, list):
             candidate = [candidate]
 
         candidate = ["=".join(line.split(" ", 1)) for line in candidate if line]
-        for command in candidate:
-            if command.strip(): # skip blank lines from creating a `config -d ""`
-                if '=' not in command:  # assignment via `=` means set a vaule
-                    command = 'sudo config -d "{0}"'.format(command.strip())
-                    # print(command)
+        command = 'sudo config'
+        for line in candidate:
+            if line.strip(): # skip blank lines from creating a `config -d ""`
+                if '=' not in line:  # assignment via `=` means set a vaule
+                    command += ' -d "{0}"'.format(line.strip())
                 else:  # no assignment, means delete the value
-                    command = 'sudo config -s "{0}"'.format(command.strip())
-                    # print(command)
-                output = self._send_command(command)
-                if "error" in output or "not found" in output:
-                    raise MergeConfigException("Command '{0}' cannot be applied.".format(command))
+                    command += ' -s "{0}"'.format(line.strip())
+        command += ' -r serialconfig'
+        output = self._send_command(command)
+        if "error" in output or "not found" in output:
+            raise MergeConfigException("Command '{0}' cannot be applied.".format(command))
         self.loaded = True
 
     def get_config(self, retrieve='all'):


### PR DESCRIPTION
- When the candidate is passed as a text blob, split it into separate
lines, otherwise it'll attempt to load the entire blob as:

```
sudo config -s "config.alerts.migrated=on
config.auth.extendedsessionids on
config.auth.type Local
config.console.flow None
config.console.ppp.auth None

...
"
```

(notice that the ``=`` is placed only on the first line, therefore it
breaks the usage).

- As per
https://opengear.zendesk.com/hc/en-us/articles/216371123-Configuring-from-the-command-line,
under the _Hints & tips_, it is pointed out that

>  You can chain config commands, this can be significantly faster than
running separate commands as config.xml is only read/written once.

Not only that on the device itself it is faster to send only one
command, but also when executing hundreds of *config* commands over SSH
is obviously suboptimal (and also safer as if it fails, it fails
altogether rather than having loaded something already, which is more
in-line with the usual NAPALM methodology).